### PR TITLE
Report container's last termination state if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 CHANGELOG
 =========
 
-## HEAD (Unreleased)
+## Unreleased
 
----
+### Added
+
+- Pod warnings and errors now include a container's termination state and
+  message, if present. By default the termination message is read from
+  `/dev/termination-log` but can be configured with `terminationMessagePath` or
+  `terminationMessagePolicy`. (https://github.com/pulumi/cloud-ready-checks/pull/17)
 
 ## 1.1.0 (2022-12-13)
 

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/text v0.15.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -62,12 +62,12 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
+golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
-golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
+golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=

--- a/internal/workflows/kubernetes/pod/crashLoopBackoff.json
+++ b/internal/workflows/kubernetes/pod/crashLoopBackoff.json
@@ -1,0 +1,186 @@
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"crashloop\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"bash\",\"-c\",\"echo \\\"see ya!\\\" \\u0026\\u0026 exit 1\"],\"image\":\"bash\",\"name\":\"crash\"}]}}\n"
+      },
+      "creationTimestamp": "2024-07-03T18:34:07Z",
+      "name": "crashloop",
+      "namespace": "default",
+      "resourceVersion": "2433921",
+      "uid": "53231e83-c78f-4442-bd06-72cf432e382a"
+    },
+    "spec": {
+      "containers": [
+        {
+          "command": ["bash", "-c", "echo \"see ya!\" \u0026\u0026 exit 1"],
+          "image": "bash",
+          "imagePullPolicy": "Always",
+          "name": "crash",
+          "resources": {},
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+              "name": "kube-api-access-p9w6w",
+              "readOnly": true
+            }
+          ]
+        }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "enableServiceLinks": true,
+      "nodeName": "orbstack",
+      "preemptionPolicy": "PreemptLowerPriority",
+      "priority": 0,
+      "restartPolicy": "Always",
+      "schedulerName": "default-scheduler",
+      "securityContext": {},
+      "serviceAccount": "default",
+      "serviceAccountName": "default",
+      "terminationGracePeriodSeconds": 30,
+      "tolerations": [
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        },
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        }
+      ],
+      "volumes": [
+        {
+          "name": "kube-api-access-p9w6w",
+          "projected": {
+            "defaultMode": 420,
+            "sources": [
+              {
+                "serviceAccountToken": {
+                  "expirationSeconds": 3607,
+                  "path": "token"
+                }
+              },
+              {
+                "configMap": {
+                  "items": [
+                    {
+                      "key": "ca.crt",
+                      "path": "ca.crt"
+                    }
+                  ],
+                  "name": "kube-root-ca.crt"
+                }
+              },
+              {
+                "downwardAPI": {
+                  "items": [
+                    {
+                      "fieldRef": {
+                        "apiVersion": "v1",
+                        "fieldPath": "metadata.namespace"
+                      },
+                      "path": "namespace"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T18:34:10Z",
+          "status": "True",
+          "type": "PodReadyToStartContainers"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T18:34:07Z",
+          "status": "True",
+          "type": "Initialized"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T18:34:07Z",
+          "message": "containers with unready status: [crash]",
+          "reason": "ContainersNotReady",
+          "status": "False",
+          "type": "Ready"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T18:34:07Z",
+          "message": "containers with unready status: [crash]",
+          "reason": "ContainersNotReady",
+          "status": "False",
+          "type": "ContainersReady"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T18:34:07Z",
+          "status": "True",
+          "type": "PodScheduled"
+        }
+      ],
+      "containerStatuses": [
+        {
+          "containerID": "docker://ebc8fb6798e2a70af9efd2480cd48f89f25fb8879e1e57b47c3253f53d38fb2c",
+          "image": "bash:latest",
+          "imageID": "docker-pullable://bash@sha256:4b5f0dfc184cd521d6cd01d0dc8096cdb216b1d7f0a2d23f6e7577be97997434",
+          "lastState": {
+            "terminated": {
+              "containerID": "docker://ebc8fb6798e2a70af9efd2480cd48f89f25fb8879e1e57b47c3253f53d38fb2c",
+              "exitCode": 1,
+              "finishedAt": "2024-07-03T18:34:11Z",
+              "reason": "Error",
+              "startedAt": "2024-07-03T18:34:11Z"
+            }
+          },
+          "name": "crash",
+          "ready": false,
+          "restartCount": 1,
+          "started": false,
+          "state": {
+            "waiting": {
+              "message": "back-off 10s restarting failed container=crash pod=crashloop_default(53231e83-c78f-4442-bd06-72cf432e382a)",
+              "reason": "CrashLoopBackOff"
+            }
+          }
+        }
+      ],
+      "hostIP": "198.19.249.2",
+      "hostIPs": [
+        {
+          "ip": "198.19.249.2"
+        },
+        {
+          "ip": "fd07:b51a:cc66::2"
+        }
+      ],
+      "phase": "Running",
+      "podIP": "192.168.194.100",
+      "podIPs": [
+        {
+          "ip": "192.168.194.100"
+        },
+        {
+          "ip": "fd07:b51a:cc66:a::15c"
+        }
+      ],
+      "qosClass": "BestEffort",
+      "startTime": "2024-07-03T18:34:07Z"
+    }
+  }
+]

--- a/internal/workflows/kubernetes/pod/crashLoopBackoffWithFallbackToLogsOnError.json
+++ b/internal/workflows/kubernetes/pod/crashLoopBackoffWithFallbackToLogsOnError.json
@@ -1,0 +1,187 @@
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"name\":\"crashloop\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"command\":[\"bash\",\"-c\",\"echo \\\"see ya!\\\" \\u0026\\u0026 exit 1\"],\"image\":\"bash\",\"name\":\"crash\",\"terminationMessagePolicy\":\"FallbackToLogsOnError\"}]}}\n"
+      },
+      "creationTimestamp": "2024-07-03T17:45:57Z",
+      "name": "crashloop",
+      "namespace": "default",
+      "resourceVersion": "2430274",
+      "uid": "0c5eddea-a859-4ee2-bb6a-4f4d0b786d85"
+    },
+    "spec": {
+      "containers": [
+        {
+          "command": ["bash", "-c", "echo \"see ya!\" \u0026\u0026 exit 1"],
+          "image": "bash",
+          "imagePullPolicy": "Always",
+          "name": "crash",
+          "resources": {},
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+              "name": "kube-api-access-dn8md",
+              "readOnly": true
+            }
+          ]
+        }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "enableServiceLinks": true,
+      "nodeName": "orbstack",
+      "preemptionPolicy": "PreemptLowerPriority",
+      "priority": 0,
+      "restartPolicy": "Always",
+      "schedulerName": "default-scheduler",
+      "securityContext": {},
+      "serviceAccount": "default",
+      "serviceAccountName": "default",
+      "terminationGracePeriodSeconds": 30,
+      "tolerations": [
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        },
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        }
+      ],
+      "volumes": [
+        {
+          "name": "kube-api-access-dn8md",
+          "projected": {
+            "defaultMode": 420,
+            "sources": [
+              {
+                "serviceAccountToken": {
+                  "expirationSeconds": 3607,
+                  "path": "token"
+                }
+              },
+              {
+                "configMap": {
+                  "items": [
+                    {
+                      "key": "ca.crt",
+                      "path": "ca.crt"
+                    }
+                  ],
+                  "name": "kube-root-ca.crt"
+                }
+              },
+              {
+                "downwardAPI": {
+                  "items": [
+                    {
+                      "fieldRef": {
+                        "apiVersion": "v1",
+                        "fieldPath": "metadata.namespace"
+                      },
+                      "path": "namespace"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "status": {
+      "conditions": [
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T17:46:00Z",
+          "status": "True",
+          "type": "PodReadyToStartContainers"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T17:45:57Z",
+          "status": "True",
+          "type": "Initialized"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T17:45:57Z",
+          "message": "containers with unready status: [crash]",
+          "reason": "ContainersNotReady",
+          "status": "False",
+          "type": "Ready"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T17:45:57Z",
+          "message": "containers with unready status: [crash]",
+          "reason": "ContainersNotReady",
+          "status": "False",
+          "type": "ContainersReady"
+        },
+        {
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-07-03T17:45:57Z",
+          "status": "True",
+          "type": "PodScheduled"
+        }
+      ],
+      "containerStatuses": [
+        {
+          "containerID": "docker://1025601c3c247cb80bdfb48819266d5b19969a307fa0d2e526b2899cb1571fbf",
+          "image": "bash:latest",
+          "imageID": "docker-pullable://bash@sha256:4b5f0dfc184cd521d6cd01d0dc8096cdb216b1d7f0a2d23f6e7577be97997434",
+          "lastState": {
+            "terminated": {
+              "containerID": "docker://1025601c3c247cb80bdfb48819266d5b19969a307fa0d2e526b2899cb1571fbf",
+              "exitCode": 1,
+              "finishedAt": "2024-07-03T17:47:36Z",
+              "message": "see ya!\n",
+              "reason": "Error",
+              "startedAt": "2024-07-03T17:47:36Z"
+            }
+          },
+          "name": "crash",
+          "ready": false,
+          "restartCount": 4,
+          "started": false,
+          "state": {
+            "waiting": {
+              "message": "back-off 1m20s restarting failed container=crash pod=crashloop_default(0c5eddea-a859-4ee2-bb6a-4f4d0b786d85)",
+              "reason": "CrashLoopBackOff"
+            }
+          }
+        }
+      ],
+      "hostIP": "198.19.249.2",
+      "hostIPs": [
+        {
+          "ip": "198.19.249.2"
+        },
+        {
+          "ip": "fd07:b51a:cc66::2"
+        }
+      ],
+      "phase": "Running",
+      "podIP": "192.168.194.99",
+      "podIPs": [
+        {
+          "ip": "192.168.194.99"
+        },
+        {
+          "ip": "fd07:b51a:cc66:a::15b"
+        }
+      ],
+      "qosClass": "BestEffort",
+      "startTime": "2024-07-03T17:45:57Z"
+    }
+  }
+]

--- a/pkg/kubernetes/pod/check.go
+++ b/pkg/kubernetes/pod/check.go
@@ -15,6 +15,7 @@
 package pod
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -64,13 +65,11 @@ func podInitialized(obj interface{}) checker.Result {
 		case corev1.ConditionTrue:
 			result.Ok = true
 		default:
-			var errs []string
+			var err error
 			for _, status := range pod.Status.ContainerStatuses {
-				if ok, containerErrs := hasContainerStatusErrors(status); !ok {
-					errs = append(errs, containerErrs...)
-				}
+				err = errors.Join(err, containerStatusErrors(status))
 			}
-			result.Message = logging.WarningMessage(podError(condition, errs, kubernetes.FullyQualifiedName(pod)))
+			result.Message = logging.WarningMessage(podError(condition, err, kubernetes.FullyQualifiedName(pod)))
 		}
 	}
 
@@ -91,8 +90,8 @@ func podReady(obj interface{}) checker.Result {
 			case corev1.PodSucceeded: // If the Pod has terminated, but .status.phase is "Succeeded", consider it Ready.
 				result.Ok = true
 			default:
-				errs := collectContainerStatusErrors(pod.Status.ContainerStatuses)
-				result.Message = logging.WarningMessage(podError(condition, errs, kubernetes.FullyQualifiedName(pod)))
+				err := collectContainerStatusErrors(pod.Status.ContainerStatuses)
+				result.Message = logging.WarningMessage(podError(condition, err, kubernetes.FullyQualifiedName(pod)))
 			}
 		}
 	}
@@ -104,64 +103,74 @@ func podReady(obj interface{}) checker.Result {
 // Helpers
 //
 
-func collectContainerStatusErrors(statuses []corev1.ContainerStatus) []string {
-	var errs []string
+func collectContainerStatusErrors(statuses []corev1.ContainerStatus) error {
+	var err error
 	for _, status := range statuses {
-		if hasErr, containerErrs := hasContainerStatusErrors(status); hasErr {
-			errs = append(errs, containerErrs...)
-		}
+		err = errors.Join(err, containerStatusErrors(status))
 	}
 
-	return errs
+	return err
 }
 
-func hasContainerStatusErrors(status corev1.ContainerStatus) (bool, []string) {
+func containerStatusErrors(status corev1.ContainerStatus) error {
 	if status.Ready {
-		return false, nil
+		return nil
 	}
 
-	var errs []string
-	if hasErr, err := hasContainerWaitingError(status); hasErr {
-		errs = append(errs, err)
-	}
-	if hasErr, err := hasContainerTerminatedError(status); hasErr {
-		errs = append(errs, err)
-	}
-
-	return len(errs) > 0, errs
+	var err error
+	err = errors.Join(err, containerWaitingError(status))
+	err = errors.Join(err, containerTerminatedError(status))
+	err = errors.Join(err, containerLastTerminationState(status))
+	return err
 }
 
-func hasContainerWaitingError(status corev1.ContainerStatus) (bool, string) {
+func containerWaitingError(status corev1.ContainerStatus) error {
 	state := status.State.Waiting
 	if state == nil {
-		return false, ""
+		return nil
 	}
 
-	// Return false if the container is creating.
+	// Return no error if the container is creating.
 	if state.Reason == "ContainerCreating" {
-		return false, ""
+		return nil
 	}
 
 	msg := fmt.Sprintf("[%s] %s", state.Reason, trimImagePullMsg(state.Message))
-	return true, msg
+	return fmt.Errorf(msg)
 }
 
-func hasContainerTerminatedError(status corev1.ContainerStatus) (bool, string) {
+func containerTerminatedError(status corev1.ContainerStatus) error {
 	state := status.State.Terminated
 	if state == nil {
-		return false, ""
+		return nil
 	}
 
 	// Return false if no reason given.
 	if len(state.Reason) == 0 {
-		return false, ""
+		return nil
 	}
 
 	if len(state.Message) > 0 {
 		msg := fmt.Sprintf("[%s] %s", state.Reason, trimImagePullMsg(state.Message))
-		return true, msg
+		return fmt.Errorf(msg)
 	}
-	return true, fmt.Sprintf("Container %q completed with exit code %d", status.Name, state.ExitCode)
+	return fmt.Errorf("Container %q completed with exit code %d", status.Name, state.ExitCode)
+}
+
+func containerLastTerminationState(status corev1.ContainerStatus) error {
+	terminated := status.LastTerminationState.Terminated
+	if terminated == nil {
+		return nil
+	}
+
+	err := fmt.Errorf("Container %q terminated at %s (%s: exit code %d)",
+		status.Name, terminated.FinishedAt, terminated.Reason, terminated.ExitCode,
+	)
+
+	if terminated.Message != "" {
+		err = errors.Join(err, fmt.Errorf(terminated.Message))
+	}
+	return err
 }
 
 // trimImagePullMsg trims unhelpful error from ImagePullError status messages.
@@ -190,15 +199,13 @@ func filterConditions(conditions []corev1.PodCondition, desired corev1.PodCondit
 	return nil, false
 }
 
-func podError(condition *corev1.PodCondition, errs []string, name string) string {
+func podError(condition *corev1.PodCondition, err error, name string) string {
 	errMsg := fmt.Sprintf("[Pod %s]: ", name)
 	if len(condition.Reason) > 0 && len(condition.Message) > 0 {
 		errMsg += condition.Message
 	}
-
-	for _, err := range errs {
-		errMsg += fmt.Sprintf(" -- %s", err)
+	if err != nil {
+		errMsg += err.Error()
 	}
-
 	return errMsg
 }

--- a/pkg/kubernetes/pod/check.go
+++ b/pkg/kubernetes/pod/check.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pulumi/cloud-ready-checks/pkg/checker"
 	"github.com/pulumi/cloud-ready-checks/pkg/checker/logging"
@@ -164,7 +165,7 @@ func containerLastTerminationState(status corev1.ContainerStatus) error {
 	}
 
 	err := fmt.Errorf("Container %q terminated at %s (%s: exit code %d)",
-		status.Name, terminated.FinishedAt, terminated.Reason, terminated.ExitCode,
+		status.Name, terminated.FinishedAt.UTC().Format(time.RFC3339Nano), terminated.Reason, terminated.ExitCode,
 	)
 
 	if terminated.Message != "" {

--- a/pkg/kubernetes/pod/check_test.go
+++ b/pkg/kubernetes/pod/check_test.go
@@ -201,7 +201,7 @@ func Test_Pod_Checker(t *testing.T) {
 			name:          "crashLoopBackoff",
 			workflowPaths: []string{workflow(crashLoopBackoff)},
 			expectReady:   false,
-			expectMessage: `Container "crash" terminated at 2024-07-03 11:34:11 -0700 PDT (Error: exit code 1)`,
+			expectMessage: `Container "crash" terminated at 2024-07-03T18:34:11Z (Error: exit code 1)`,
 		},
 		{
 			name:          "crashLoopBackoff with FallbackToLogsOnError",


### PR DESCRIPTION
Motivated by this comment https://github.com/pulumi/pulumi-kubernetes/issues/535#issuecomment-2198381634.

If the container has a last termination state we include some information like the exit code, reason for termination and time of termination. For example:

```
Waiting for Pod "crashloop" to be ready -- [Pod crashloop]: containers with unready status: [crash][CrashLoopBackOff] back-off 1m20s restarting failed container=crash pod=crashloop_default(0c5eddea-a859-4ee2-bb6a-4f4d0b786d85)
Container "crash" terminated at 2024-07-03T17:47:36Z (Error: exit code 1)
<termination message>
```

Note the termination message will only be present if it was correctly [configured](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/).

This changes error handling slightly to use `errors.Join` which as a side effect separates multiple errors by newlines. This should make the post-update summary more readable, especially in cases where multiple containers crashed or had other problems.