### PR TITLE
Don't log an empty warning if pod is unready with ready containers

### DIFF
--- a/internal/workflows/kubernetes/pod/unavailable.json
+++ b/internal/workflows/kubernetes/pod/unavailable.json
@@ -1,0 +1,132 @@
+[
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "creationTimestamp": "2019-06-25T04:55:12Z",
+      "labels": {
+        "app.kubernetes.io/managed-by": "pulumi"
+      },
+      "name": "foo",
+      "namespace": "default",
+      "resourceVersion": "389619",
+      "selfLink": "/api/v1/namespaces/default/pods/foo",
+      "uid": "6a799bf5-9705-11e9-a3c5-025000000001"
+    },
+    "spec": {
+      "containers": [
+        {
+          "image": "nginx:1.13-alpine",
+          "imagePullPolicy": "IfNotPresent",
+          "name": "nginx",
+          "resources": {},
+          "terminationMessagePath": "/dev/termination-log",
+          "terminationMessagePolicy": "File",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+              "name": "default-token-544qd",
+              "readOnly": true
+            }
+          ]
+        }
+      ],
+      "dnsPolicy": "ClusterFirst",
+      "enableServiceLinks": true,
+      "nodeName": "docker-desktop",
+      "priority": 0,
+      "restartPolicy": "Always",
+      "schedulerName": "default-scheduler",
+      "securityContext": {},
+      "serviceAccount": "default",
+      "serviceAccountName": "default",
+      "terminationGracePeriodSeconds": 30,
+      "tolerations": [
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/not-ready",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        },
+        {
+          "effect": "NoExecute",
+          "key": "node.kubernetes.io/unreachable",
+          "operator": "Exists",
+          "tolerationSeconds": 300
+        }
+      ],
+      "volumes": [
+        {
+          "name": "default-token-544qd",
+          "secret": {
+            "defaultMode": 420,
+            "secretName": "default-token-544qd"
+          }
+        }
+      ]
+    },
+    "status": {
+      "phase": "Running",
+      "conditions": [
+        {
+          "type": "PodReadyToStartContainers",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-09-13T04:28:02Z"
+        },
+        {
+          "type": "Initialized",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-09-13T04:28:00Z"
+        },
+        {
+          "type": "Ready",
+          "status": "False",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-09-13T12:03:27Z"
+        },
+        {
+          "type": "ContainersReady",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-09-13T04:28:02Z"
+        },
+        {
+          "type": "PodScheduled",
+          "status": "True",
+          "lastProbeTime": null,
+          "lastTransitionTime": "2024-09-13T04:28:00Z"
+        }
+      ],
+      "hostIP": "10.0.33.223",
+      "hostIPs": [
+        {
+          "ip": "10.0.33.223"
+        }
+      ],
+      "podIP": "10.0.44.69",
+      "podIPs": [
+        {
+          "ip": "10.0.44.69"
+        }
+      ],
+      "startTime": "2024-09-13T04:28:00Z",
+      "containerStatuses": [
+        {
+          "name": "app",
+          "state": {
+            "running": {
+              "startedAt": "2024-09-13T04:28:01Z"
+            }
+          },
+          "lastState": {},
+          "ready": true,
+          "restartCount": 0,
+          "started": true
+        }
+      ],
+      "qosClass": "Burstable"
+    }
+  }
+]


### PR DESCRIPTION
Luke ran into a situation where a pod's containers were all ready but the pod's Ready condition was still False. We were logging an empty message because we didn't have any container errors to report:

> warning: [Pod app-6734a272-cf7f4c4fd-vtr48]:

This PR changes our logic to only append the informational warning if there's a non-nil error or if the condition actually has a message to report.

An "unavailable" test was added to reproduce the issue. Existing tests were extended to capture more of the messages we expect.