### PR TITLE
Update Changelog for v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## Unreleased
 
+## 1.2.0 (2024-12-11)
+
 ### Added
 
 - Pod warnings and errors now include a container's termination state and
@@ -10,7 +12,12 @@ CHANGELOG
   `/dev/termination-log` but can be configured with `terminationMessagePath` or
   `terminationMessagePolicy`. (https://github.com/pulumi/cloud-ready-checks/pull/17)
 
-## 1.1.0 (2022-12-13)
+### Changed
+
+- Upgrade Kubernetes client libraries to v0.32.0 (https://github.com/pulumi/cloud-ready-checks/pull/61)
+- Upgrade Go to v1.23 (https://github.com/pulumi/cloud-ready-checks/pull/54)
+
+## 1.1.0 (2023-12-13)
 
 - Upgrade Go to v1.21 (https://github.com/pulumi/cloud-ready-checks/pull/5)
 - Upgrade pulumi/pulumi to v3.96.2 (https://github.com/pulumi/cloud-ready-checks/pull/6)


### PR DESCRIPTION
The changelog wasn't updated as part of tagging the v1.2.0 release. Updating retrospectively. 