### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: ci
 on:
   pull_request:
@@ -10,6 +17,9 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Install Go
@@ -21,4 +31,4 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@015f24e6818733317a2da2edd6290ab26238649a # v5
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
